### PR TITLE
setup packages for development mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,13 @@
   "dependencies": {
     "bootstrap": "^3.3.7",
     "file-saver": "^1.3.3",
+    "flux": "3.1.2",
+    "keymirror": "0.1.1",
     "moment": "^2.18.1",
     "react": "^15.5.4",
     "react-bootstrap": "^0.30.8",
     "react-dom": "^15.5.4",
+    "react-file-reader-input": "1.1.0",
     "react-router-dom": "^4.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
`npm install` was exiting cleanly but these packages were missing after running install.

tested on `nodejs v6.11.0`