### PR TITLE
fix gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ yarn-error.log*
 
 # generated css
 src/**/*.css
+!src/index.css


### PR DESCRIPTION
`index.css` is required to run the app but the gitignore was excluding it. it's probably populated in your local checkout. If there is any contents in it, can you commit them after this PR merges?