### PR TITLE
Back store with localStorage

### DIFF
--- a/src/stores/GameStore.js
+++ b/src/stores/GameStore.js
@@ -6,7 +6,7 @@ const CHANGE_GAME_EVENT = "changeGame";
 const MAX_PROSPERITY = 64;
 
 // default object avoids null issues throughout app before a game is loaded
-let _game = {
+let _game = Object.assign({}, {
   "name": "",
   "prosperity": 0,
   "donations": 0,
@@ -24,10 +24,27 @@ let _game = {
     "scenario": -1,
     "monsters": []
   }
-};
+}, getGameLocalStorage());
 
 function setGame(game) {
+  setGameLocalStorage(game);
   _game = game;
+}
+
+function getGameLocalStorage() {
+  try {
+    return JSON.parse(window.localStorage.getItem('game'));
+  }
+  catch (e) {
+    return { };
+  }
+}
+
+function setGameLocalStorage(game) {
+  try {
+    window.localStorage.setItem('game', JSON.stringify(game));
+  }
+  catch (e) { }
 }
 
 function changeProsperity(amount) {
@@ -45,7 +62,7 @@ function changeProsperity(amount) {
 }
 
 function changeGame(game) {
-  _game = game;
+  setGame(game);
 }
 
 class GameStoreClass extends EventEmitter {

--- a/src/stores/GameStore.js
+++ b/src/stores/GameStore.js
@@ -6,7 +6,7 @@ const CHANGE_GAME_EVENT = "changeGame";
 const MAX_PROSPERITY = 64;
 
 // default object avoids null issues throughout app before a game is loaded
-let _game = Object.assign({}, {
+let _game = Object.assign({
   "name": "",
   "prosperity": 0,
   "donations": 0,


### PR DESCRIPTION
I see there's some feature work and requests to back `GameStore` with various storage tools like DropBox, Google Drive, etc.. That's all well and fine and a great solution for cross-device play, but seems a little heavy duty. After all, the size of the store is only a couple kilobytes.

This pull request backs `GameStore` with `localStorage`. We will be well under the 5mb limit imposed by nearly every browser and should make storing/recalling your campaigns more seamless.

I'm happy to address any fears or concerns or make additional changes to the PR.