### PR TITLE
feat(Prosperity): add prosperity summary log

### DIFF
--- a/src/actions/GameActions.js
+++ b/src/actions/GameActions.js
@@ -56,10 +56,11 @@ export default {
     });
   },
 
-  changeProsperity(amount) {
+  changeProsperity(amount, source) {
     AppDispatcher.dispatch({
       actionType: GameConstants.CHANGE_PROSPERITY,
-      amount: amount
+      amount: amount,
+      source
     });
   }
 

--- a/src/components/Prosperity.js
+++ b/src/components/Prosperity.js
@@ -283,17 +283,31 @@ class ProsperityComponent extends Component {
 	constructor() {
     super();
 
-    this.state = GameStore.getGame();
+    this.state = Object.assign({},{prosperityTable: false}, GameStore.getGame());
 
     this.onChange = this.onChange.bind(this);
   }
 
-  increaseProsperity() {
-  	GameActions.changeProsperity(1);
+  getIncreaseProsperity(source) {
+    return (event) => {
+      event.preventDefault();
+      this.increaseProsperity(source);
+    }
   }
 
-  decreaseProsperity() {
-  	GameActions.changeProsperity(-1);
+  increaseProsperity(source) {
+    GameActions.changeProsperity(1, source);
+  }
+
+  getDecreaseProsperity(source) {
+    return (event) => {
+      event.preventDefault();
+      this.decreaseProsperity(source);
+    }
+  }
+
+  decreaseProsperity(source) {
+    GameActions.changeProsperity(-1, source);
   }
 
   donateToGreatOak(amount) {
@@ -318,19 +332,16 @@ class ProsperityComponent extends Component {
     	}
     }
 
-    let newProsperity = this.state.prosperity + prosperityChange;
-
-    if (newProsperity > 64) {
-    	newProsperity = 64;
+    if(prosperityChange>0) {
+      this.increaseProsperity("Donations")
     }
 
-    if (newProsperity < 0) {
-    	newProsperity = 0;
+    if(prosperityChange<0) {
+      this.decreaseProsperity("Donations")
     }
 
     this.setState({
-      donations: newDonations,
-      prosperity: newProsperity
+      donations: newDonations
     }, function() {
       GameActions.changeGame(this.state);
     });
@@ -475,7 +486,66 @@ class ProsperityComponent extends Component {
   	return availableTreasures;
   }
 
+  getProsperity() {
+    const {prosperityTable, prosperityLog} = this.state;
+
+    if (prosperityTable) {
+      return (
+        <Row>
+          <Col>
+            <Table striped condensed hover>
+              <thead>
+                <tr>
+                  <th>Source</th>
+                  <th>Amount</th>
+                </tr>
+              </thead>
+              <tbody>
+                {prosperityLog.map(({amount, source}, index) => {
+                  return (
+                    <tr key={index}>
+                      <td>{source}</td>
+                      <td>{amount}</td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </Table>
+          </Col>
+        </Row>
+      )
+    }
+    let prosperityChecks = [];
+
+    for (let i=1; i<=this.state.prosperity; i++) {
+      if ([4, 9, 15, 22, 30, 39, 50, 64].indexOf(i) > -1) {
+        prosperityChecks.push(<Glyphicon className="milestone" glyph="check" key={i} />);
+      }
+      else {
+        prosperityChecks.push(<Glyphicon glyph="check" key={i} />);
+      }
+    }
+
+    for (let i=this.state.prosperity + 1; i<=64; i++) {
+      if ([4, 9, 15, 22, 30, 39, 50, 64].indexOf(i) > -1) {
+        prosperityChecks.push(<Glyphicon className="milestone" glyph="unchecked" key={i} />);
+      }
+      else {
+        prosperityChecks.push(<Glyphicon glyph="unchecked" key={i} />);
+      }
+    }
+
+    return (
+      <Row className="prosperity-checks-list" key="pros-2">
+        <Col xs={12} md={12}>
+          {prosperityChecks}
+        </Col>
+      </Row>
+    );
+  }
+
   render() {
+    const {prosperityTable} = this.state;
   	// treasures
   	let treasureColumns = [];
 
@@ -543,26 +613,47 @@ class ProsperityComponent extends Component {
 	      		</Col>
 	      	</Row>
       		<Row>
-      			<Col xs={12} md={8} className="prosperity-checks-container">
-      				<Row>
-      					<Col xs={12} md={12} className="text-center">
-									<h2>Prosperity</h2>
-								</Col>
-								<Col xs={12} md={12} className="prosperity-label-container text-center">
-									<Label className="label-xxlarge label-brute">{level}</Label>
-								</Col>
-      					<Col xs={6} md={6}>
-      						<Button href="#" className="btn-lightning" block onClick={this.decreaseProsperity.bind(this)}><Glyphicon glyph="minus" /></Button>
-      					</Col>
-      					<Col xs={6} md={6}>
-      						<Button href="#" className="btn-scoundrel" block onClick={this.increaseProsperity.bind(this)}><Glyphicon glyph="plus" /></Button>
-      					</Col>
-      				</Row>
-							<Row className="prosperity-checks-list">
-								<Col xs={12} md={12}>
-									{prosperityChecks}
-								</Col>
-							</Row>
+            <Col xs={12} md={8} className="prosperity-checks-container">
+              <Row key="pros-1">
+                <Col xs={12} md={12} className="text-center">
+                  <h2>Prosperity</h2>
+                </Col>
+                <Col xs={12} md={12} className="prosperity-label-container text-center">
+                  <Label className="label-xxlarge label-brute">{level}</Label>
+                </Col>
+                <Col xs={3} md={3}>
+                  <Button href="#" className="btn-lightning" block onClick={this.getDecreaseProsperity("Road Event")}><Glyphicon glyph="minus" /> Road Event</Button>
+                </Col>
+                <Col xs={3} md={3}>
+                  <Button href="#" className="btn-lightning" block onClick={this.getDecreaseProsperity("City Event")}><Glyphicon glyph="minus" /> City Event</Button>
+                </Col>
+                <Col xs={3} md={3}>
+                  <Button href="#" className="btn-lightning" block onClick={this.getDecreaseProsperity("Scenario")}><Glyphicon glyph="minus" /> Scenario</Button>
+                </Col>
+                <Col xs={3} md={3}>
+                  <Button href="#" className="btn-lightning" block onClick={this.getDecreaseProsperity("Character Retirement")}><Glyphicon glyph="minus" /> Character Retirement</Button>
+                </Col>
+                <Col xs={3} md={3}>
+                  <Button href="#" className="btn-scoundrel" block onClick={this.getIncreaseProsperity("Road Event")}><Glyphicon glyph="plus" /> Road Event</Button>
+                </Col>
+                <Col xs={3} md={3}>
+                  <Button href="#" className="btn-scoundrel" block onClick={this.getIncreaseProsperity("City Event")}><Glyphicon glyph="plus" /> City Event</Button>
+                </Col>
+                <Col xs={3} md={3}>
+                  <Button href="#" className="btn-scoundrel" block onClick={this.getIncreaseProsperity("Scenario")}><Glyphicon glyph="plus" /> Scenario</Button>
+                </Col>
+                <Col xs={3} md={3}>
+                  <Button href="#" className="btn-scoundrel" block onClick={this.getIncreaseProsperity("Character Retirement")}><Glyphicon glyph="plus" /> Character Retirement</Button>
+                </Col>
+              </Row>
+              {this.getProsperity()}
+              <Row className="prosperity-checks-list" key="pros-3">
+                <Col xs={12} md={12}>
+                  <Button href="#" className="btn-lightning" block onClick={()=>this.setState({prosperityTable: !prosperityTable})}>
+                    {prosperityTable ? "Show Prosperity" : "Show Summary Log"}
+                  </Button>
+                </Col>
+              </Row>
 							<Row>
       					<Col xs={12} md={12} className="text-center">
 									<h2>Sanctuary of the Great Oak</h2>

--- a/src/stores/GameStore.js
+++ b/src/stores/GameStore.js
@@ -9,6 +9,7 @@ const MAX_PROSPERITY = 64;
 let _game = Object.assign({
   "name": "",
   "prosperity": 0,
+  "prosperityLog": [],
   "donations": 0,
   "partyLocation": "",
   "partyNotes": "",
@@ -47,7 +48,7 @@ function setGameLocalStorage(game) {
   catch (e) { }
 }
 
-function changeProsperity(amount) {
+function changeProsperity(amount, source) {
   let newProsperity = _game.prosperity + amount;
 
   if (newProsperity > MAX_PROSPERITY) {
@@ -58,7 +59,10 @@ function changeProsperity(amount) {
     newProsperity = 0;
   }
 
+  _game.prosperityLog = [..._game.prosperityLog, {amount, source}];
+
   _game.prosperity = newProsperity;
+  setGame(_game);
 }
 
 function changeGame(game) {
@@ -106,7 +110,7 @@ GameStore.dispatchToken = AppDispatcher.register(action => {
       break;
 
     case GameConstants.CHANGE_PROSPERITY:
-      changeProsperity(action.amount);
+      changeProsperity(action.amount, action.source);
       GameStore.emitGameChange();
       break;
 


### PR DESCRIPTION
Add a summary log for the prosperity changes source. This also adds basic buttons for City/Road
Events character retirement and scenarios. Also the donations auto increment already supports this
way.

![image](https://user-images.githubusercontent.com/156010/32463016-cae37346-c33b-11e7-9552-68e70567c3da.png)

![image](https://user-images.githubusercontent.com/156010/32462994-b72725fa-c33b-11e7-8c80-01aaa0cf5e41.png)

I do think that this is not final but I hope that we can massage this until it is in a good state and hopefully this is a step into the right direction. Thanks for you feedback.

Closes #22