### PR TITLE
Fix missing incomplete requirement for Scenario 34 (Scorched Summit)

### DIFF
--- a/src/components/Scenarios.js
+++ b/src/components/Scenarios.js
@@ -214,7 +214,7 @@ export const SCENARIOS = [
   { 
     title: "Scorched Summit",
     globalAchievementsRequired: [],
-    globalAchievementsRequiredIncomplete: [],
+    globalAchievementsRequiredIncomplete: [ACHIEVEMENTS.GLOBAL_ACHIEVEMENTS.THE_DRAKE_AIDED],
     partyAchievementsRequired: [PARTY.PARTY_ACHIEVEMENTS.THE_DRAKES_COMMAND] 
   },
   { 


### PR DESCRIPTION
Scorched Summit is only available if Party Achievement **"The Drakes Command"** is complete, and Global Achievement **"The Drake Aided"** is incomplete.

*From latest version of the scenario book:*

![image](https://user-images.githubusercontent.com/4244316/44623734-9f3b8a00-a92a-11e8-8401-8319a2a4ef10.png)
